### PR TITLE
Introduce way to run pytest-pythonhashseed on Windows

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,13 +5,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-latest']
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version:
         - '3.8'
         - '3.9'
         - '3.10'
         - '3.11'
         - '3.12'
+        - '3.13'
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,6 +7,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version:
+        - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,6 +13,7 @@ jobs:
         - '3.11'
         - '3.12'
         - '3.13'
+      fail-fast: false
     steps:
     - uses: actions/checkout@v4
 
@@ -30,4 +31,4 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest
+        pytest -v

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,6 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
         python-version:
-        - '3.7'
         - '3.8'
         - '3.9'
         - '3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ test = [
     'pytest',
     'pytest-cov',
     'pytest-ruff',
-    'ruff==0.1.15',
+    'ruff',
 ]
 
 [project.urls]

--- a/pytest_pythonhashseed/__init__.py
+++ b/pytest_pythonhashseed/__init__.py
@@ -69,4 +69,4 @@ def pytest_configure(config):
         result = subprocess.run(argv, check=False, env=os.environ)  # noqa: S603
         os._exit(result.returncode)
     else:
-        os.execvpe(argv[0], argv, os.environ)  # noqa: S606
+        os.execvpe(argv[0], argv, env=os.environ)  # noqa: S606

--- a/pytest_pythonhashseed/__init__.py
+++ b/pytest_pythonhashseed/__init__.py
@@ -66,7 +66,7 @@ def pytest_configure(config):
         # time to actually run the tests. So we use subprocess.run to run the
         # tests in the new process and then force exit the original process.
         # pytest doesn't like sys.exit, so we use os._exit instead.
-        result = subprocess.run(argv, env=os.environ)
+        result = subprocess.run(argv, check=False, env=os.environ)  # noqa: S603
         os._exit(result.returncode)
     else:
         os.execvpe(argv[0], argv, os.environ)  # noqa: S606

--- a/pytest_pythonhashseed/__init__.py
+++ b/pytest_pythonhashseed/__init__.py
@@ -67,7 +67,6 @@ def pytest_configure(config):
         # immediately terminates. This means that the new process does not have
         # time to actually run the tests. So we use subprocess.run to run the
         # tests in the new process and then force exit the original process.
-        # pytest doesn't like sys.exit, so we use os._exit instead.
         result = subprocess.run(argv, check=False, env=os.environ)  # noqa: S603
         pytest.exit(
             returncode=result.returncode,

--- a/pytest_pythonhashseed/__init__.py
+++ b/pytest_pythonhashseed/__init__.py
@@ -18,6 +18,8 @@ import os
 import subprocess
 import sys
 
+import pytest
+
 __version__ = '1.0.1'
 __author__ = 'Michael Samoglyadov'
 __license__ = 'Apache License, Version 2.0'
@@ -67,6 +69,11 @@ def pytest_configure(config):
         # tests in the new process and then force exit the original process.
         # pytest doesn't like sys.exit, so we use os._exit instead.
         result = subprocess.run(argv, check=False, env=os.environ)  # noqa: S603
-        os._exit(result.returncode)
+        pytest.exit(
+            f'Unit tests failed: {result.returncode}\n'
+            f'{result.stdout}\n'
+            f'{result.stderr}',
+            result.returncode,
+        )
     else:
         os.execvpe(argv[0], argv, env=os.environ)  # noqa: S606

--- a/pytest_pythonhashseed/__init__.py
+++ b/pytest_pythonhashseed/__init__.py
@@ -70,10 +70,7 @@ def pytest_configure(config):
         # pytest doesn't like sys.exit, so we use os._exit instead.
         result = subprocess.run(argv, check=False, env=os.environ)  # noqa: S603
         pytest.exit(
-            f'Unit tests failed: {result.returncode}\n'
-            f'{result.stdout}\n'
-            f'{result.stderr}',
-            result.returncode,
+            returncode=result.returncode,
         )
     else:
         os.execvpe(argv[0], argv, env=os.environ)  # noqa: S606

--- a/pytest_pythonhashseed/__init__.py
+++ b/pytest_pythonhashseed/__init__.py
@@ -15,6 +15,7 @@
 """Pytest plugin to set PYTHONHASHSEED env var."""
 
 import os
+import subprocess
 import sys
 
 __version__ = '1.0.1'
@@ -47,7 +48,9 @@ def pytest_configure(config):
 
     module_spec = sys.modules['__main__'].__spec__
 
-    if module_spec is None:  # run as standalone script
+    if (
+        module_spec is None or module_spec.name == '__main__'
+    ):  # run as standalone script
         argv = sys.argv
     else:  # run as `python -m ...`
         # abspath to module instead of binary in argv[0] in this case
@@ -56,4 +59,14 @@ def pytest_configure(config):
         argv = [sys.executable, '-m', module_name, *sys.argv[1:]]
 
     os.environ['PYTHONHASHSEED'] = str(opt_hashseed)
-    os.execvpe(argv[0], argv, os.environ)  # noqa: S606
+
+    if sys.platform == 'win32':
+        # On Windows, os.execvpe re-spawns a process, but the original process
+        # immediately terminates. This means that the new process does not have
+        # time to actually run the tests. So we use subprocess.run to run the
+        # tests in the new process and then force exit the original process.
+        # pytest doesn't like sys.exit, so we use os._exit instead.
+        result = subprocess.run(argv, env=os.environ)
+        os._exit(result.returncode)
+    else:
+        os.execvpe(argv[0], argv, os.environ)  # noqa: S606

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -21,7 +21,8 @@ def _assert_platform_specific_calls(
     assert mock_obj.call_args.args[-1] == expected_env
     if expected_extra_args:
         actual_args = mock_obj.call_args.args[1]
-        assert actual_args == expected_extra_args
+        expected_args = expected_extra_args + sys.argv[1:]
+        assert actual_args == expected_args
 
 
 def test_pytest_addoption():

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -4,6 +4,26 @@ from unittest.mock import MagicMock, patch
 import pytest_pythonhashseed as plugin
 
 
+def _get_platform_specific_patches():
+    """Return the appropriate patch context manager based on platform."""
+    if sys.platform == 'win32':
+        return patch('subprocess.run')
+    return patch('os.execve')
+
+
+def _assert_platform_specific_calls(
+    mock_obj,
+    expected_extra_args=None,
+    expected_env=None,
+):
+    """Assert platform-specific calls based on the current platform."""
+    mock_obj.assert_called_once()
+    assert mock_obj.call_args.args[-1] == expected_env
+    if expected_extra_args:
+        actual_args = mock_obj.call_args.args[1]
+        assert actual_args == expected_extra_args
+
+
 def test_pytest_addoption():
     parser = MagicMock()
     group = MagicMock()
@@ -21,11 +41,11 @@ def test_pytest_configure_opt_not_defined():
     config = MagicMock()
     config.getoption.return_value = None
 
-    with patch('os.execve') as execve:
+    with _get_platform_specific_patches() as mock_func:
         plugin.pytest_configure(config)
 
         config.getoption.assert_called_once_with('pythonhashseed')
-        execve.assert_not_called()
+        mock_func.assert_not_called()
 
 
 @patch.dict('os.environ', {'SMTH': '1'}, clear=True)
@@ -33,15 +53,16 @@ def test_pytest_configure_opt_set_env_not():
     config = MagicMock()
     config.getoption.return_value = 42
 
-    with patch('os.execve') as execve:
+    with _get_platform_specific_patches() as mock_func:
         plugin.pytest_configure(config)
 
         config.getoption.assert_called_once_with('pythonhashseed')
-        execve.assert_called_once()
-        assert execve.call_args.args[2] == {
-            'PYTHONHASHSEED': '42',
-            'SMTH': '1',
-        }
+
+        expected_env = {'PYTHONHASHSEED': '42', 'SMTH': '1'}
+        _assert_platform_specific_calls(
+            mock_func,
+            expected_env=expected_env,
+        )
 
 
 @patch.dict('os.environ', {'PYTHONHASHSEED': '42'}, clear=True)
@@ -49,11 +70,11 @@ def test_pytest_configure_opt_match_env():
     config = MagicMock()
     config.getoption.return_value = 42
 
-    with patch('os.execve') as execve:
+    with _get_platform_specific_patches() as mock_func:
         plugin.pytest_configure(config)
 
         config.getoption.assert_called_once_with('pythonhashseed')
-        execve.assert_not_called()
+        mock_func.assert_not_called()
 
 
 @patch.dict('os.environ', {'PYTHONHASHSEED': '42', 'SMTH': '1'}, clear=True)
@@ -61,12 +82,16 @@ def test_pytest_configure_opt_mismatch_env():
     config = MagicMock()
     config.getoption.return_value = 0
 
-    with patch('os.execve') as execve:
+    with _get_platform_specific_patches() as mock_func:
         plugin.pytest_configure(config)
 
         config.getoption.assert_called_once_with('pythonhashseed')
-        execve.assert_called_once()
-        assert execve.call_args.args[2] == {'PYTHONHASHSEED': '0', 'SMTH': '1'}
+
+        expected_env = {'PYTHONHASHSEED': '0', 'SMTH': '1'}
+        _assert_platform_specific_calls(
+            mock_func,
+            expected_env=expected_env,
+        )
 
 
 @patch.dict('os.environ', {'PYTHONHASHSEED': '42'}, clear=True)
@@ -79,11 +104,17 @@ def test_pytest_configure_opt_mismatch_env_run_as_module():
     mod.__spec__.name = 'pytest_module_name.__main__'
 
     with patch.dict('sys.modules', {'__main__': mod}):  # noqa: SIM117
-        with patch('os.execve') as execve:
+        with _get_platform_specific_patches() as mock_func:
             plugin.pytest_configure(config)
 
-            assert execve.call_args.args[1][:3] == [
+            expected_extra_args = [
                 sys.executable,
                 '-m',
                 'pytest_module_name',
             ]
+            expected_env = {'PYTHONHASHSEED': '0'}
+            _assert_platform_specific_calls(
+                mock_func,
+                expected_extra_args=expected_extra_args,
+                expected_env=expected_env,
+            )

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -20,6 +20,7 @@ def _assert_platform_specific_calls(
     mock_obj.assert_called_once()
     assert mock_obj.call_args.args[-1] == expected_env
     if expected_extra_args:
+        print(mock_obj.call_args.args)
         actual_args = mock_obj.call_args.args[1]
         expected_args = expected_extra_args + sys.argv[1:]
         assert actual_args == expected_args

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -28,7 +28,6 @@ def _assert_platform_specific_calls(
         expected_arg_len = 2
     assert len(mock_obj.call_args.args) == expected_arg_len
     if expected_extra_args:
-        print(mock_obj.call_args.args)  # noqa: T201
         actual_args = mock_obj.call_args.args[1]
         expected_args = expected_extra_args + sys.argv[1:]
         assert actual_args == expected_args

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -19,8 +19,8 @@ def _assert_platform_specific_calls(
 ):
     """Assert platform-specific calls based on the current platform."""
     mock_obj.assert_called_once()
-    assert mock_obj.call_args.args[-1] == expected_env
-    assert mock_obj.call_args.kwargs == {}
+
+    assert mock_obj.call_args.kwargs == {'env': expected_env}
     if sys.platform == 'win32':
         assert mock_obj.call_args.args[2] is False  # check=False
         expected_arg_len = 3

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -9,7 +9,7 @@ def _get_platform_specific_patches():
     if sys.platform == 'win32':
         return patch('subprocess.run', return_value=MagicMock(returncode=0))
 
-    return patch('os.execve')
+    return patch('os.execvpe')
 
 
 def _assert_platform_specific_calls(
@@ -20,6 +20,13 @@ def _assert_platform_specific_calls(
     """Assert platform-specific calls based on the current platform."""
     mock_obj.assert_called_once()
     assert mock_obj.call_args.args[-1] == expected_env
+    assert mock_obj.call_args.kwargs == {}
+    if sys.platform == 'win32':
+        assert mock_obj.call_args.args[2] is False  # check=False
+        expected_arg_len = 3
+    else:
+        expected_arg_len = 2
+    assert len(mock_obj.call_args.args) == expected_arg_len
     if expected_extra_args:
         print(mock_obj.call_args.args)  # noqa: T201
         actual_args = mock_obj.call_args.args[1]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -7,7 +7,10 @@ import pytest_pythonhashseed as plugin
 def _get_platform_specific_patches():
     """Return the appropriate patch context manager based on platform."""
     if sys.platform == 'win32':
-        return patch('subprocess.run')
+        subprocess = patch('subprocess.run')
+        subprocess.return_value.returncode = 0
+        return subprocess
+
     return patch('os.execve')
 
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -20,7 +20,7 @@ def _assert_platform_specific_calls(
     mock_obj.assert_called_once()
     assert mock_obj.call_args.args[-1] == expected_env
     if expected_extra_args:
-        print(mock_obj.call_args.args)
+        print(mock_obj.call_args.args)  # noqa: T201
         actual_args = mock_obj.call_args.args[1]
         expected_args = expected_extra_args + sys.argv[1:]
         assert actual_args == expected_args

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -7,9 +7,7 @@ import pytest_pythonhashseed as plugin
 def _get_platform_specific_patches():
     """Return the appropriate patch context manager based on platform."""
     if sys.platform == 'win32':
-        subprocess = patch('subprocess.run')
-        subprocess.return_value.returncode = 0
-        return subprocess
+        return patch('subprocess.run', return_value=MagicMock(returncode=0))
 
     return patch('os.execve')
 


### PR DESCRIPTION
On Windows, os.execvpe re-spawns a process, but the original process immediately terminates. This means that the new process does not have time to actually run the tests. Alternatively, we can use subprocess.run to run the tests in a new process and then force exit the original process manually to prevent running the tests twice.

I've also expanded the unit tests to run on macOS and Windows.