### PR TITLE
Special case NOP for VSCode extension, as it breaks

### DIFF
--- a/pytest_pythonhashseed/__init__.py
+++ b/pytest_pythonhashseed/__init__.py
@@ -62,7 +62,7 @@ def pytest_configure(config):
         argv = [sys.executable, '-m', module_name, *sys.argv[1:]]
 
     if argv[0].split('/')[-2:] == ['vscode_pytest', 'run_pytest_script.py']:
-        warnings.warn(f"Detected vscode_pytest, skipping PYTHONHASHSEED")
+        warnings.warn('Detected vscode_pytest, skipping PYTHONHASHSEED', stacklevel=2)
         return
 
     os.environ['PYTHONHASHSEED'] = str(opt_hashseed)

--- a/pytest_pythonhashseed/__init__.py
+++ b/pytest_pythonhashseed/__init__.py
@@ -63,7 +63,7 @@ def pytest_configure(config):
 
     if argv[0].split('/')[-2:] == ['vscode_pytest', 'run_pytest_script.py']:
         warnings.warn(
-            'Detected vscode_pytest, skipping PYTHONHASHSEED', stacklevel=2
+            'Detected vscode_pytest, skipping PYTHONHASHSEED', stacklevel=2,
         )
         return
 

--- a/pytest_pythonhashseed/__init__.py
+++ b/pytest_pythonhashseed/__init__.py
@@ -62,7 +62,9 @@ def pytest_configure(config):
         argv = [sys.executable, '-m', module_name, *sys.argv[1:]]
 
     if argv[0].split('/')[-2:] == ['vscode_pytest', 'run_pytest_script.py']:
-        warnings.warn('Detected vscode_pytest, skipping PYTHONHASHSEED', stacklevel=2)
+        warnings.warn(
+            'Detected vscode_pytest, skipping PYTHONHASHSEED', stacklevel=2
+        )
         return
 
     os.environ['PYTHONHASHSEED'] = str(opt_hashseed)

--- a/pytest_pythonhashseed/__init__.py
+++ b/pytest_pythonhashseed/__init__.py
@@ -63,7 +63,8 @@ def pytest_configure(config):
 
     if argv[0].split('/')[-2:] == ['vscode_pytest', 'run_pytest_script.py']:
         warnings.warn(
-            'Detected vscode_pytest, skipping PYTHONHASHSEED', stacklevel=2,
+            'Detected vscode_pytest, skipping PYTHONHASHSEED',
+            stacklevel=2,
         )
         return
 

--- a/pytest_pythonhashseed/__init__.py
+++ b/pytest_pythonhashseed/__init__.py
@@ -17,6 +17,7 @@
 import os
 import subprocess
 import sys
+import warnings
 
 import pytest
 
@@ -59,6 +60,10 @@ def pytest_configure(config):
         # see details in https://bugs.python.org/issue23427#msg371022
         module_name = module_spec.name.rsplit('.', 1)[0]
         argv = [sys.executable, '-m', module_name, *sys.argv[1:]]
+
+    if argv[0].split('/')[-2:] == ['vscode_pytest', 'run_pytest_script.py']:
+        warnings.warn(f"Detected vscode_pytest, skipping PYTHONHASHSEED")
+        return
 
     os.environ['PYTHONHASHSEED'] = str(opt_hashseed)
 


### PR DESCRIPTION
If run through the VSCode extension, pytest_pythonhashseed breaks with the following error:
```
Running pytest with args: ['-p', 'vscode_pytest', '--rootdir=/Users/valentinhuber/GitHub/fandango', '/Users/valentinhuber/GitHub/fandango/tests/test_havoc.py::test_wrapping_add']
INTERNALERROR> Traceback (most recent call last):
INTERNALERROR>   File "/Users/valentinhuber/GitHub/fandango/.venv/lib/python3.13/site-packages/_pytest/main.py", line 285, in wrap_session
INTERNALERROR>     config._do_configure()
INTERNALERROR>     ~~~~~~~~~~~~~~~~~~~~^^
INTERNALERROR>   File "/Users/valentinhuber/GitHub/fandango/.venv/lib/python3.13/site-packages/_pytest/config/__init__.py", line 1119, in _do_configure
INTERNALERROR>     self.hook.pytest_configure.call_historic(kwargs=dict(config=self))
INTERNALERROR>     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/valentinhuber/GitHub/fandango/.venv/lib/python3.13/site-packages/pluggy/_hooks.py", line 534, in call_historic
INTERNALERROR>     res = self._hookexec(self.name, self._hookimpls.copy(), kwargs, False)
INTERNALERROR>   File "/Users/valentinhuber/GitHub/fandango/.venv/lib/python3.13/site-packages/pluggy/_manager.py", line 120, in _hookexec
INTERNALERROR>     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
INTERNALERROR>            ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/valentinhuber/GitHub/fandango/.venv/lib/python3.13/site-packages/pluggy/_callers.py", line 167, in _multicall
INTERNALERROR>     raise exception
INTERNALERROR>   File "/Users/valentinhuber/GitHub/fandango/.venv/lib/python3.13/site-packages/pluggy/_callers.py", line 121, in _multicall
INTERNALERROR>     res = hook_impl.function(*args)
INTERNALERROR>   File "/Users/valentinhuber/GitHub/fandango/.venv/lib/python3.13/site-packages/pytest_pythonhashseed/__init__.py", line 80, in pytest_configure
INTERNALERROR>     os.execvpe(argv[0], argv, env=os.environ)  # noqa: S606
INTERNALERROR>     ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "<frozen os>", line 621, in execvpe
INTERNALERROR>   File "<frozen os>", line 635, in _execvpe
INTERNALERROR> OSError: [Errno 8] Exec format error: '/Users/valentinhuber/.cursor/extensions/ms-python.python-2025.6.1-darwin-arm64/python_files/vscode_pytest/run_pytest_script.py'
Finished running tests!

```